### PR TITLE
feat: 投稿画面の作成

### DIFF
--- a/src/components/post/ImageUploadArea.tsx
+++ b/src/components/post/ImageUploadArea.tsx
@@ -1,0 +1,141 @@
+import React, { useRef, useState, useCallback } from 'react';
+import { cn } from '@/lib/utils';
+
+interface ImageUploadAreaProps {
+  images: File[];
+  onImagesChange: (images: File[]) => void;
+  maxImages?: number;
+}
+
+const ImageUploadArea: React.FC<ImageUploadAreaProps> = ({
+  images,
+  onImagesChange,
+  maxImages = 4,
+}) => {
+  const [isDragging, setIsDragging] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileSelect = useCallback(
+    (files: FileList | null) => {
+      if (!files) return;
+
+      const imageFiles = Array.from(files).filter((file) =>
+        file.type.startsWith('image/')
+      );
+
+      const remainingSlots = maxImages - images.length;
+      const filesToAdd = imageFiles.slice(0, remainingSlots);
+
+      if (filesToAdd.length > 0) {
+        onImagesChange([...images, ...filesToAdd]);
+      }
+    },
+    [images, maxImages, onImagesChange]
+  );
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setIsDragging(false);
+      handleFileSelect(e.dataTransfer.files);
+    },
+    [handleFileSelect]
+  );
+
+  const handleFileInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      handleFileSelect(e.target.files);
+      // 同じファイルを選択できるようにリセット
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
+    },
+    [handleFileSelect]
+  );
+
+  const handleRemoveImage = useCallback(
+    (index: number) => {
+      const newImages = images.filter((_, i) => i !== index);
+      onImagesChange(newImages);
+    },
+    [images, onImagesChange]
+  );
+
+  const canAddMore = images.length < maxImages;
+
+  return (
+    <div className="space-y-4">
+      {canAddMore && (
+        <div
+          className={cn(
+            'border-2 border-dashed rounded-lg p-8 text-center transition-colors',
+            isDragging
+              ? 'border-primary bg-primary/5'
+              : 'border-gray-300 bg-gray-50'
+          )}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+        >
+          <div className="space-y-2">
+            <p className="text-sm text-gray-600">
+              写真をここにドラッグ&ドロップ
+            </p>
+            <p className="text-xs text-gray-500">
+              またはファイルを選択(最大{maxImages}枚)
+            </p>
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="mt-4 px-4 py-2 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300 transition-colors text-sm"
+            >
+              ファイルを選択
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              multiple
+              onChange={handleFileInputChange}
+              className="hidden"
+            />
+          </div>
+        </div>
+      )}
+
+      {images.length > 0 && (
+        <div className="grid grid-cols-2 gap-4">
+          {images.map((image, index) => (
+            <div key={index} className="relative group">
+              <img
+                src={URL.createObjectURL(image)}
+                alt={`Preview ${index + 1}`}
+                className="w-full h-48 object-cover rounded-lg"
+              />
+              <button
+                type="button"
+                onClick={() => handleRemoveImage(index)}
+                className="absolute top-2 right-2 bg-red-500 text-white rounded-full w-6 h-6 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity text-xs"
+              >
+                ×
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ImageUploadArea;
+

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,25 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Textarea.displayName = "Textarea"
+
+export { Textarea }
+

--- a/src/pages/CreatePostPage.tsx
+++ b/src/pages/CreatePostPage.tsx
@@ -1,0 +1,138 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Header from '@/components/layout/Header';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import ImageUploadArea from '@/components/post/ImageUploadArea';
+
+const CreatePostPage: React.FC = () => {
+  const navigate = useNavigate();
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [images, setImages] = useState<File[]>([]);
+  const [errors, setErrors] = useState<{
+    title?: string;
+    description?: string;
+    images?: string;
+  }>({});
+
+  const MAX_TITLE_LENGTH = 20;
+
+  const validateForm = (): boolean => {
+    const newErrors: typeof errors = {};
+
+    if (!title.trim()) {
+      newErrors.title = 'タイトルを入力してください';
+    } else if (title.length > MAX_TITLE_LENGTH) {
+      newErrors.title = `タイトルは${MAX_TITLE_LENGTH}文字以内で入力してください`;
+    }
+
+    if (!description.trim()) {
+      newErrors.description = '説明を入力してください';
+    }
+
+    if (images.length === 0) {
+      newErrors.images = '画像を1枚以上アップロードしてください';
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!validateForm()) {
+      return;
+    }
+
+    // TODO: API処理を実装
+    console.log('投稿データ:', {
+      title,
+      description,
+      images,
+    });
+
+    // 仮の処理: 投稿一覧画面へ遷移（投稿一覧画面が未実装のため仮）
+    // TODO: 投稿一覧画面が実装されたら、適切なパスに変更
+    navigate('/posts');
+  };
+
+  const handleCancel = () => {
+    // 入力内容を破棄して投稿一覧画面へ遷移
+    // TODO: 投稿一覧画面が実装されたら、適切なパスに変更
+    navigate('/posts');
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col" style={{ backgroundColor: '#FBFBF5' }}>
+      <Header />
+      <main className="flex-1 max-w-4xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-8">
+        <div className="space-y-8">
+          <form onSubmit={handleSubmit} className="space-y-6">
+            {/* 画像アップロードエリア */}
+            <div>
+              <ImageUploadArea images={images} onImagesChange={setImages} maxImages={4} />
+              {errors.images && <p className="mt-2 text-sm text-red-600">{errors.images}</p>}
+            </div>
+
+            {/* タイトル入力 */}
+            <div className="space-y-2">
+              <Label htmlFor="title">タイトル</Label>
+              <div className="flex items-center gap-2">
+                <Input
+                  id="title"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  maxLength={MAX_TITLE_LENGTH}
+                  placeholder="タイトルを入力"
+                  className={errors.title ? 'border-red-500' : ''}
+                />
+                <span className="text-sm text-gray-500 whitespace-nowrap">
+                  {title.length}/{MAX_TITLE_LENGTH}
+                </span>
+              </div>
+              {errors.title && <p className="text-sm text-red-600">{errors.title}</p>}
+            </div>
+
+            {/* 説明入力 */}
+            <div className="space-y-2">
+              <Label htmlFor="description">説明</Label>
+              <Textarea
+                id="description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="部屋のこだわりやアイテムについて説明しよう"
+                rows={6}
+                className={errors.description ? 'border-red-500' : ''}
+              />
+              {errors.description && <p className="text-sm text-red-600">{errors.description}</p>}
+            </div>
+
+            {/* フッターボタン（画面下部） */}
+            <div className="flex justify-end gap-4 pt-4">
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={handleCancel}
+                className="text-gray-600"
+              >
+                キャンセル
+              </Button>
+              <Button
+                type="submit"
+                className="bg-yellow-400 hover:bg-yellow-500 text-gray-900 font-medium"
+              >
+                投稿
+              </Button>
+            </div>
+          </form>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default CreatePostPage;


### PR DESCRIPTION
- shadcn/uiのTextareaコンポーネントを追加
- 画像アップロードコンポーネント（ImageUploadArea）を作成
  - ドラッグ&ドロップ対応
  - 最大4枚までアップロード可能
  - 画像プレビュー・削除機能
- 投稿画面（CreatePostPage）を作成
  - タイトル入力（最大20文字、文字数カウント）
  - 説明入力
  - フォームバリデーション
  - 投稿・キャンセルボタン（仮実装）
- 背景色を#FBFBF5に変更

TODO:
- 投稿ボタンのAPI処理実装
- Header.tsxに投稿画面用ボタン追加
- 投稿一覧画面実装後のルーティング修正

<img width="1588" height="907" alt="投稿画面" src="https://github.com/user-attachments/assets/8d7d9270-07f4-402d-9cdb-c7bb9c8f4759" />


